### PR TITLE
Add Flask-based ElevenLabs Scribe transcription app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+instance/
+*.log

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A lightweight Flask application that lets you upload existing meeting recordings
 
 ## Getting started
 
+> 💡 There is no hosted demo. To try the app you need to run the Flask server locally so the frontend can talk to the backend that proxies ElevenLabs' API.
+
 1. **Clone & set up the project**
 
    ```bash
@@ -38,18 +40,21 @@ A lightweight Flask application that lets you upload existing meeting recordings
 
 3. **Run the development server**
 
+   With the virtual environment active, start Flask:
+
    ```bash
-   flask --app app run
+   flask --app app run  # or `python app.py`
    ```
 
-   The application will be available at http://127.0.0.1:5000/.
+   This boots both the UI and the API at http://127.0.0.1:5000/. Open that URL in a browser tab to use the app interactively.
 
-4. **Transcribe audio**
+4. **Use the app**
 
-   - Upload a meeting recording from disk, _or_
-   - Click **Start recording** to capture audio via your microphone, then choose **Transcribe recording**.
+   - When prompted, grant your browser permission to use the microphone so recording works.
+   - Click **Start recording** to capture a clip in the browser, then **Transcribe recording** once you're done. The audio is streamed through the Flask backend to ElevenLabs for transcription.
+   - Alternatively, drag an existing audio file into the upload box and press **Transcribe file**.
 
-   Once the API responds, the transcript will appear on the page. If you enable summaries, the summary card will populate when Scribe returns summary data.
+   After ElevenLabs finishes processing, the transcript (and any optional summary) is rendered directly in the results panel on the same page.
 
 ## Notes on the Scribe API
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,55 @@ A lightweight Flask application that lets you upload existing meeting recordings
 
    After ElevenLabs finishes processing, the transcript (and any optional summary) is rendered directly in the results panel on the same page.
 
+## Sharing your copy on GitHub (beginner friendly)
+
+If you only see the README file on GitHub right now, it just means you have not pushed the rest of the project yet. Follow these steps once and your full copy of the app will appear on GitHub. The instructions are written for absolute beginners—just go in order.
+
+1. **Create an empty GitHub repository**
+
+   1. Sign in at [https://github.com](https://github.com).
+   2. Click the ➕ in the top-right corner and choose **New repository**.
+   3. Give it a name (for example `scribe-app`) and press **Create repository**. Do not add a README, `.gitignore`, or license—the project already has those.
+
+2. **Get the project onto your computer (only once)**
+
+   ```bash
+   # If you do not already have git installed, download it from https://git-scm.com/downloads
+   git clone https://github.com/your-username/scribe-app.git
+   cd scribe-app
+   ```
+
+   If you already downloaded a ZIP from this project earlier, open that ZIP, copy its contents, and paste/replace them inside the new `scribe-app` folder you just cloned. You should see files such as `app.py`, `requirements.txt`, `static/`, and `templates/` next to `README.md`.
+
+3. **Save (commit) the project locally**
+
+   ```bash
+   git status             # Shows which files are ready
+   git add .              # Stage everything
+   git commit -m "Add Scribe meeting transcriber"
+   ```
+
+   After the commit finishes you can type `git status` again. If it says “nothing to commit, working tree clean” you are ready for the final step.
+
+4. **Push (upload) the commit to GitHub**
+
+   ```bash
+   git push origin main   # or "master" if GitHub named your default branch that
+   ```
+
+   Refresh your repository page on GitHub. All of the project files—including the app, frontend assets, and this README—will now be visible. From this point forward, whenever you make changes locally repeat only steps 3 and 4 to update GitHub.
+
+### Alternative: upload without using the command line
+
+If you prefer not to install git, you can also upload through the GitHub website:
+
+1. Create a new repository as in step 1 above.
+2. Click **uploading an existing file** on the empty repository page.
+3. Drag the entire project folder (or individual files) into the browser window.
+4. Scroll down, write a short commit message, and click **Commit changes**.
+
+This method is slower for future updates but works fine if you only need to upload the project once.
+
 ## Notes on the Scribe API
 
 - The backend proxies requests to `https://api.elevenlabs.io/v1/speech-to-text/stream` and forwards optional parameters such as diarization, speaker labels, summaries, and temperature.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# Scribe-app
-scribe powered app
+# Scribe Meeting Transcriber
+
+A lightweight Flask application that lets you upload existing meeting recordings or capture fresh audio in the browser, then sends the audio to ElevenLabs' Scribe v1 speech-to-text API for transcription.
+
+
+## Features
+
+- Upload audio files (`.wav`, `.mp3`, `.m4a`, etc.) for transcription
+- Record audio directly in the browser using the MediaRecorder API
+- Optional transcription settings, including diarization, speaker labels, summaries, and temperature adjustments
+- Displays the transcript and optional summaries returned by Scribe v1
+- Built with vanilla HTML/CSS/JS on top of a Flask backend
+
+## Requirements
+
+- Python 3.10+
+- An ElevenLabs API key with access to the Scribe v1 speech-to-text API
+
+## Getting started
+
+1. **Clone & set up the project**
+
+   ```bash
+   git clone <repo-url>
+   cd Scribe-app
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+   pip install -r requirements.txt
+   ```
+
+2. **Configure environment variables**
+
+   Create a `.env` file in the project root (or export variables another way) and set your ElevenLabs key:
+
+   ```env
+   ELEVENLABS_API_KEY=your_xi_api_key
+   ```
+
+3. **Run the development server**
+
+   ```bash
+   flask --app app run
+   ```
+
+   The application will be available at http://127.0.0.1:5000/.
+
+4. **Transcribe audio**
+
+   - Upload a meeting recording from disk, _or_
+   - Click **Start recording** to capture audio via your microphone, then choose **Transcribe recording**.
+
+   Once the API responds, the transcript will appear on the page. If you enable summaries, the summary card will populate when Scribe returns summary data.
+
+## Notes on the Scribe API
+
+- The backend proxies requests to `https://api.elevenlabs.io/v1/speech-to-text/stream` and forwards optional parameters such as diarization, speaker labels, summaries, and temperature.
+- Ensure the authenticated account has access to Scribe v1; otherwise, the ElevenLabs API may respond with an authorization error.
+- The proxy responds with `502` errors when the upstream request fails—check the JSON payload for details when debugging.
+
+## Production tips
+
+- Consider fronting the Flask application with a production-ready WSGI server such as `gunicorn`.
+- Secure the `/api/transcriptions` endpoint (e.g., via authentication) if you deploy this publicly.
+- Modern browsers require HTTPS to access the microphone. When deploying, ensure the app is served over HTTPS so the MediaRecorder API can function.
+
+## License
+
+MIT

--- a/app.py
+++ b/app.py
@@ -1,0 +1,130 @@
+import os
+from typing import Tuple
+
+import requests
+from dotenv import load_dotenv
+from flask import Flask, jsonify, render_template, request
+from flask_cors import CORS
+
+load_dotenv()
+
+app = Flask(__name__)
+CORS(app)
+
+SCRIBE_TRANSCRIBE_URL = "https://api.elevenlabs.io/v1/speech-to-text/stream"
+
+
+class ElevenLabsError(Exception):
+    """Raised when the ElevenLabs API returns an error."""
+
+
+class MissingApiKeyError(Exception):
+    """Raised when the ELEVENLABS_API_KEY env var is missing."""
+
+
+def _require_api_key() -> str:
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    if not api_key:
+        raise MissingApiKeyError(
+            "ELEVENLABS_API_KEY environment variable is not set."
+        )
+    return api_key
+
+
+def _call_scribe_api(file_tuple: Tuple[str, bytes, str], 
+                     diarize: bool, 
+                     language: str,
+                     punctuate: bool,
+                     speaker_labels: bool,
+                     summarize: bool,
+                     temperature: float,
+                     model: str) -> dict:
+    api_key = _require_api_key()
+    headers = {
+        "xi-api-key": api_key,
+    }
+    data = {
+        "model_id": model,
+        "diarize": str(diarize).lower(),
+        "language": language,
+        "punctuate": str(punctuate).lower(),
+        "speaker_labels": str(speaker_labels).lower(),
+        "summarize": str(summarize).lower(),
+        "temperature": str(temperature),
+    }
+    files = {
+        "file": file_tuple,
+    }
+
+    response = requests.post(
+        SCRIBE_TRANSCRIBE_URL,
+        headers=headers,
+        data=data,
+        files=files,
+        timeout=120,
+    )
+
+    if response.status_code >= 400:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"detail": response.text}
+        raise ElevenLabsError(payload.get("detail", payload))
+    try:
+        return response.json()
+    except ValueError as exc:  # pragma: no cover - protective
+        raise ElevenLabsError("Unexpected response from ElevenLabs") from exc
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.post("/api/transcriptions")
+def create_transcription():
+    if "audio" not in request.files:
+        return jsonify({"error": "Missing audio file"}), 400
+
+    audio_file = request.files["audio"]
+    diarize = request.form.get("diarize", "false").lower() == "true"
+    language = request.form.get("language", "en")
+    punctuate = request.form.get("punctuate", "true").lower() == "true"
+    speaker_labels = request.form.get("speaker_labels", "false").lower() == "true"
+    summarize = request.form.get("summarize", "false").lower() == "true"
+    try:
+        temperature = float(request.form.get("temperature", "0.5"))
+    except (TypeError, ValueError):
+        return jsonify({"error": "Temperature must be a number"}), 400
+    model = request.form.get("model", "scribe_v1")
+
+    audio_file.stream.seek(0)
+    audio_bytes = audio_file.stream.read()
+    if not audio_bytes:
+        return jsonify({"error": "Audio file is empty"}), 400
+    file_tuple = (
+        audio_file.filename or "audio.wav",
+        audio_bytes,
+        audio_file.mimetype or "application/octet-stream",
+    )
+
+    try:
+        transcript = _call_scribe_api(
+            file_tuple=file_tuple,
+            diarize=diarize,
+            language=language,
+            punctuate=punctuate,
+            speaker_labels=speaker_labels,
+            summarize=summarize,
+            temperature=temperature,
+            model=model,
+        )
+    except MissingApiKeyError as missing_key_error:
+        return jsonify({"error": str(missing_key_error)}), 500
+    except ElevenLabsError as api_error:
+        return jsonify({"error": str(api_error)}), 502
+    return jsonify({"transcript": transcript})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==3.0.3
+python-dotenv==1.0.1
+requests==2.32.3
+Flask-Cors==4.0.1

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #f4f7ff, #d9e9ff);
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0 0 2rem;
+  background: transparent;
+  color: #0f172a;
+}
+
+.app-header {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+}
+
+.app-header h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-radius: 18px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.12);
+  padding: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.4rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+label span {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+}
+
+input[type="file"],
+select,
+input[type="number"] {
+  width: 100%;
+  padding: 0.6rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(255, 255, 255, 0.6);
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+button {
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  border: none;
+  color: white;
+  padding: 0.75rem 1.2rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+button.secondary {
+  background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+  margin-top: 1rem;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.toggle input {
+  accent-color: #2563eb;
+}
+
+.recording-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status {
+  font-style: italic;
+  color: #475569;
+}
+
+.transcript {
+  white-space: pre-wrap;
+  background: rgba(15, 23, 42, 0.05);
+  padding: 1rem;
+  border-radius: 12px;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.summary {
+  margin-top: 1rem;
+  background: rgba(96, 165, 250, 0.12);
+  padding: 1rem;
+  border-radius: 12px;
+}
+
+.error {
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  color: #b91c1c;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  margin: 1rem 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #e2e8f0;
+  }
+
+  .card {
+    background: rgba(15, 23, 42, 0.75);
+    box-shadow: 0 12px 40px rgba(15, 23, 42, 0.7);
+  }
+
+  input[type="file"],
+  select,
+  input[type="number"] {
+    background: rgba(15, 23, 42, 0.6);
+    color: inherit;
+  }
+
+  .transcript {
+    background: rgba(15, 23, 42, 0.4);
+  }
+
+  .summary {
+    background: rgba(37, 99, 235, 0.2);
+  }
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,116 @@
+const uploadForm = document.getElementById("upload-form");
+const transcriptOutput = document.getElementById("transcript-output");
+const summaryContainer = document.getElementById("summary-container");
+const summaryOutput = document.getElementById("summary-output");
+const errorTemplate = document.getElementById("error-template");
+const recordButton = document.getElementById("record-btn");
+const recordingStatus = document.getElementById("recording-status");
+const recordingPreview = document.getElementById("recording-preview");
+const transcribeRecordingBtn = document.getElementById("transcribe-recording");
+
+let mediaRecorder;
+let recordedChunks = [];
+let recordedBlob;
+
+function showError(message) {
+  const node = errorTemplate.content.cloneNode(true);
+  node.querySelector(".error").textContent = message;
+  document.querySelector("main").prepend(node);
+}
+
+async function submitAudio(formData) {
+  transcriptOutput.textContent = "Transcribing...";
+  summaryContainer.hidden = true;
+  summaryOutput.textContent = "";
+
+  try {
+    const response = await fetch("/api/transcriptions", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: response.statusText }));
+      throw new Error(error.error || "Failed to transcribe file");
+    }
+
+    const payload = await response.json();
+    const transcript = payload.transcript;
+    const transcriptText = transcript?.text || transcript?.transcription || JSON.stringify(transcript, null, 2);
+    transcriptOutput.textContent = transcriptText;
+
+    const summary = transcript?.summary || transcript?.summaries?.[0]?.text;
+    if (summary) {
+      summaryOutput.textContent = summary;
+      summaryContainer.hidden = false;
+    }
+  } catch (error) {
+    console.error(error);
+    showError(error.message);
+    transcriptOutput.textContent = "";
+  }
+}
+
+uploadForm?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(uploadForm);
+
+  ["diarize", "speaker_labels", "summarize", "punctuate"].forEach((key) => {
+    formData.set(key, uploadForm.querySelector(`#${key.replace("_", "-")}`)?.checked);
+  });
+
+  submitAudio(formData);
+});
+
+recordButton?.addEventListener("click", async () => {
+  if (mediaRecorder && mediaRecorder.state === "recording") {
+    mediaRecorder.stop();
+    recordButton.textContent = "Start recording";
+    recordingStatus.textContent = "Processing recording...";
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaRecorder = new MediaRecorder(stream);
+    recordedChunks = [];
+
+    mediaRecorder.addEventListener("dataavailable", (event) => {
+      if (event.data.size > 0) {
+        recordedChunks.push(event.data);
+      }
+    });
+
+    mediaRecorder.addEventListener("stop", () => {
+      recordedBlob = new Blob(recordedChunks, { type: "audio/webm" });
+      recordingPreview.src = URL.createObjectURL(recordedBlob);
+      recordingPreview.hidden = false;
+      transcribeRecordingBtn.disabled = false;
+      recordingStatus.textContent = "Recording finished";
+    });
+
+    mediaRecorder.start();
+    recordButton.textContent = "Stop recording";
+    recordingStatus.textContent = "Recording...";
+    transcribeRecordingBtn.disabled = true;
+    recordingPreview.hidden = true;
+  } catch (error) {
+    console.error(error);
+    showError("Unable to access microphone: " + error.message);
+  }
+});
+
+transcribeRecordingBtn?.addEventListener("click", async () => {
+  if (!recordedBlob) return;
+  const formData = new FormData();
+  formData.append("audio", recordedBlob, "recording.webm");
+  formData.append("language", document.getElementById("language").value);
+  formData.append("model", document.getElementById("model").value);
+  formData.append("temperature", document.getElementById("temperature").value);
+  formData.append("diarize", document.getElementById("diarize").checked);
+  formData.append("speaker_labels", document.getElementById("speaker-labels").checked);
+  formData.append("summarize", document.getElementById("summarize").checked);
+  formData.append("punctuate", document.getElementById("punctuate").checked);
+
+  submitAudio(formData);
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scribe Meeting Transcriber</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Meeting Transcriber</h1>
+      <p>Upload or record audio and let ElevenLabs Scribe v1 handle the rest.</p>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <h2>Upload an audio file</h2>
+        <form id="upload-form" enctype="multipart/form-data">
+          <div class="form-group">
+            <label for="audio-file">Audio file</label>
+            <input type="file" id="audio-file" name="audio" accept="audio/*" required />
+          </div>
+          <div class="form-grid">
+            <label>
+              <span>Language</span>
+              <select name="language" id="language">
+                <option value="en">English</option>
+                <option value="es">Spanish</option>
+                <option value="fr">French</option>
+                <option value="de">German</option>
+              </select>
+            </label>
+            <label>
+              <span>Model</span>
+              <select name="model" id="model">
+                <option value="scribe_v1" selected>scribe_v1</option>
+                <option value="scribe_v1_mimi">scribe_v1_mimi</option>
+              </select>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="diarize" id="diarize" />
+              <span>Diarize speakers</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="speaker_labels" id="speaker-labels" />
+              <span>Return speaker labels</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="summarize" id="summarize" />
+              <span>Generate summary</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" name="punctuate" id="punctuate" checked />
+              <span>Auto punctuation</span>
+            </label>
+            <label>
+              <span>Temperature</span>
+              <input type="number" id="temperature" name="temperature" value="0.5" min="0" max="1" step="0.1" />
+            </label>
+          </div>
+          <button type="submit">Transcribe file</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Record audio</h2>
+        <div class="recording-controls">
+          <button id="record-btn">Start recording</button>
+          <span id="recording-status" class="status">Idle</span>
+        </div>
+        <audio id="recording-preview" controls hidden></audio>
+        <button id="transcribe-recording" class="secondary" disabled>Transcribe recording</button>
+      </section>
+
+      <section class="card output">
+        <h2>Transcript</h2>
+        <pre id="transcript-output" class="transcript"></pre>
+        <div id="summary-container" class="summary" hidden>
+          <h3>Summary</h3>
+          <p id="summary-output"></p>
+        </div>
+      </section>
+    </main>
+
+    <template id="error-template">
+      <div class="error"></div>
+    </template>
+
+    <script src="{{ url_for('static', filename='js/main.js') }}" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask backend that proxies uploads to ElevenLabs' Scribe v1 speech-to-text API
- build a responsive single-page UI for uploading files or recording audio in the browser and submitting for transcription
- document project setup, configuration, and usage instructions in the README

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d427906d008329b91adcd67586411a